### PR TITLE
(GH-14) Multi-Target .NET Core 3.1, 5 & 6 instead of .NET Standard 2.0

### DIFF
--- a/nuspec/nuget/Cake.Issues.Terraform.nuspec
+++ b/nuspec/nuget/Cake.Issues.Terraform.nuspec
@@ -28,8 +28,14 @@ See the Project Site for an overview of the whole ecosystem of addins for workin
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="netstandard2.0/Cake.Issues.Terraform.dll" target="lib\netstandard2.0" />
-    <file src="netstandard2.0/Cake.Issues.Terraform.pdb" target="lib\netstandard2.0" />
-    <file src="netstandard2.0/Cake.Issues.Terraform.xml" target="lib\netstandard2.0" />
+    <file src="netcoreapp3.1/Cake.Issues.Terraform.dll" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1/Cake.Issues.Terraform.pdb" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1/Cake.Issues.Terraform.xml" target="lib\netcoreapp3.1" />
+    <file src="net5.0/Cake.Issues.Terraform.dll" target="lib\net5.0" />
+    <file src="net5.0/Cake.Issues.Terraform.pdb" target="lib\net5.0" />
+    <file src="net5.0/Cake.Issues.Terraform.xml" target="lib\net5.0" />
+    <file src="net6.0/Cake.Issues.Terraform.dll" target="lib\net6.0" />
+    <file src="net6.0/Cake.Issues.Terraform.pdb" target="lib\net6.0" />
+    <file src="net6.0/Cake.Issues.Terraform.xml" target="lib\net6.0" />
   </files>
 </package>

--- a/src/Cake.Issues.Terraform.Tests/Cake.Issues.Terraform.Tests.csproj
+++ b/src/Cake.Issues.Terraform.Tests/Cake.Issues.Terraform.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <Description>Tests for the Cake.Issues.Terraform addin</Description>
     <Authors>Pascal Berger</Authors>

--- a/src/Cake.Issues.Terraform/Cake.Issues.Terraform.csproj
+++ b/src/Cake.Issues.Terraform/Cake.Issues.Terraform.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Description>Terraform support for the Cake.Issues Addin for Cake Build Automation System</Description>
     <Authors>Pascal Berger</Authors>
     <Product>Cake.Issues</Product>


### PR DESCRIPTION
Multi-Target .NET Core 3.1, 5, & 6 to follow best-practices for Cake 2.0.

Fixes #14